### PR TITLE
fix: モバイルでのコンテンツテキストサイズをworks.htmlに合わせる

### DIFF
--- a/css/main-mobile.css
+++ b/css/main-mobile.css
@@ -15,7 +15,7 @@ code {
 
 .main {
   width: 100%;
-  font-size: 120%;
+  font-size: 100%;
   text-align: center;
   font-family: 'PT Sans', sans-serif;
 }


### PR DESCRIPTION
.mainのfont-sizeを120%から100%に変更し、about.html等のモバイル表示で
テキストが大きすぎる問題を修正。works.htmlはpx指定のため影響なし。

https://claude.ai/code/session_019KZqWxLP7pRiGLdRiL4PPg